### PR TITLE
Modernize cli.py and add real test coverage

### DIFF
--- a/pylicense3/cli.py
+++ b/pylicense3/cli.py
@@ -21,13 +21,37 @@ import importlib.util
 import re
 import subprocess
 from collections import defaultdict
+from collections.abc import Iterator
 from pathlib import Path
+from types import ModuleType
+from typing import TextIO, TypedDict
 
 from docopt import docopt
+
+#: Leading UTF-8 byte-order-mark bytes (read as individual code points under
+#: ``errors='surrogateescape'``) that should be stripped from a file's first line.
+_BOM_BYTES = '\xef\xbb\xbf'
+
+#: Header lines that always describe boilerplate we regenerate and therefore discard.
+_DISCARDABLE_PREFIXES = ['Copyright', 'copyright', 'License']
+
+#: URL schemes used to detect stray links in an existing header.
+_URL_SCHEMES = ('http://', 'https://')
+
+#: Default copyright statement when the config does not provide one.
+_DEFAULT_COPYRIGHT = 'The copyright lies with the authors of this file (see below).'
 
 
 class GitError(Exception):
     """Raised when git metadata required for header generation cannot be computed."""
+
+
+class FileHeader(TypedDict):
+    """Parsed pieces of an existing file header that are preserved on rewrite."""
+
+    shebang: str | None
+    encoding: str | None
+    comments: list[str]
 
 
 def _compile_patterns(patterns: list[str]) -> re.Pattern[str]:
@@ -43,7 +67,13 @@ def _format_year_range(year_range: int | tuple[int, int]) -> str:
     return f'{year_range}'
 
 
-def process_dir(dirname: str, config):
+def process_dir(dirname: str, config: ModuleType) -> Iterator[tuple[str, str]]:
+    """Yield ``(filename, root)`` pairs for every file under ``dirname`` to process.
+
+    A single file is yielded directly. For a directory, files are matched against
+    the config's ``include_patterns`` (default ``['*']``) and filtered by its
+    ``exclude_patterns``.
+    """
     candidate = Path(dirname)
     if candidate.is_file():
         yield str(candidate), ''
@@ -67,6 +97,11 @@ def process_dir(dirname: str, config):
 
 
 def get_git_authors(filename: str, root: str) -> dict[str, str]:
+    """Return a mapping of author name to a formatted span of contribution years.
+
+    Years are read from ``git log`` for ``filename`` (relative to ``root``) and
+    consecutive years are collapsed into ``start - end`` ranges.
+    """
     years_per_author: dict[str, set[int]] = defaultdict(set)
     filename_path = Path(filename)
     root_path = Path(root)
@@ -127,8 +162,24 @@ def get_git_authors(filename: str, root: str) -> dict[str, str]:
     return authors
 
 
-def read_current_header(source_iter, prefix, project_name, copyright_statement, license_str, url, lead_in, lead_out):
-    header = {'shebang': None, 'encoding': None, 'comments': []}
+def read_current_header(
+    source_iter: Iterator[str | None],
+    prefix: str,
+    project_name: str,
+    copyright_statement: str,
+    license_str: str,
+    url: str | None,
+    lead_in: str | None,
+    lead_out: str | None,
+) -> tuple[FileHeader, str, str | None]:
+    """Consume and parse an existing header from ``source_iter``.
+
+    Boilerplate (project name, copyright, license, known URLs) is discarded while
+    the shebang, encoding declaration and any free-form comments are retained.
+    Returns the parsed :class:`FileHeader`, an optional warning string and the
+    first line that is *not* part of the header (or ``None`` at end of input).
+    """
+    header: FileHeader = {'shebang': None, 'encoding': None, 'comments': []}
     warning = ''
     could_be_an_author = False
     while True:
@@ -136,10 +187,7 @@ def read_current_header(source_iter, prefix, project_name, copyright_statement, 
         if line is None:
             break
 
-        dirt_to_remove = ['\xef', '\xbb', '\xbf']
-        while len(line) > 0 and line[0] in dirt_to_remove:
-            for dirt in dirt_to_remove:
-                line = line.lstrip(dirt)
+        line = line.lstrip(_BOM_BYTES)
 
         if len(line) == 0:
             break
@@ -151,25 +199,25 @@ def read_current_header(source_iter, prefix, project_name, copyright_statement, 
         if not line.startswith(prefix):
             break
 
-        can_be_discarded = ['Copyright', 'copyright', 'License']
+        can_be_discarded = list(_DISCARDABLE_PREFIXES)
         for entry in (project_name, copyright_statement, license_str):
             for raw_line in entry.split('\n'):
                 can_be_discarded.append(raw_line.strip().lstrip(prefix).strip())
 
-        line_without_prefix = line[len(prefix) :].strip()
+        line_without_prefix = line.removeprefix(prefix).strip()
         if re.match(r'.*coding[:=]\s*', line):
-            header['encoding'] = line[len(prefix) :]
+            header['encoding'] = line.removeprefix(prefix)
         elif any(line_without_prefix.startswith(discard) for discard in can_be_discarded) or (
             url and line_without_prefix.startswith(url)
         ):
             continue
-        elif any(line_without_prefix.startswith(some_url) for some_url in ('http://', 'https://')):
+        elif any(line_without_prefix.startswith(some_url) for some_url in _URL_SCHEMES):
             warning = f"dropping url '{line_without_prefix}'!"
         elif line_without_prefix.startswith('Authors:'):
             could_be_an_author = True
             continue
         elif could_be_an_author:
-            if line[len(prefix) :].startswith('  ') and line.strip()[-1:] == ')':
+            if line.removeprefix(prefix).startswith('  ') and line.strip()[-1:] == ')':
                 continue
             could_be_an_author = False
             header['comments'].append(line)
@@ -180,18 +228,23 @@ def read_current_header(source_iter, prefix, project_name, copyright_statement, 
 
 
 def write_header(
-    target,
-    header,
-    authors,
-    license_str,
-    prefix,
-    project_name,
-    url,
-    max_width,
-    copyright_statement,
-    lead_in,
-    lead_out,
-):
+    target: TextIO,
+    header: FileHeader,
+    authors: str | dict[str, str],
+    license_str: str,
+    prefix: str,
+    project_name: str,
+    url: str | None,
+    max_width: int,
+    copyright_statement: str,
+    lead_in: str | None,
+    lead_out: str | None,
+) -> None:
+    """Write a freshly generated license header (and preserved comments) to ``target``.
+
+    ``authors`` may be a pre-formatted string or a mapping of name to year span;
+    the latter is rendered as an aligned ``Authors:`` block.
+    """
     shebang, encoding = header['shebang'], header['encoding']
     if shebang:
         target.write(f'{shebang}\n')
@@ -230,9 +283,9 @@ def write_header(
                 padded_author = author.ljust(max_author_length)
             target.write(f'{prefix}   {padded_author} {year}\n')
 
-    def prune_first_empty_comments(lines):
+    def prune_first_empty_comments(lines: list[str]) -> list[str]:
         first_real_comment_line = False
-        result = []
+        result: list[str] = []
         for raw_line in lines:
             raw_line = raw_line.strip()
             if first_real_comment_line:
@@ -256,15 +309,16 @@ def write_header(
         target.write(f'{lead_out}\n')
 
 
-def process_file(filename, config, root):
+def process_file(filename: str, config: ModuleType, root: str, verbose: bool = False) -> str:
+    """Rewrite ``filename`` in place with a regenerated license header.
+
+    The existing header is parsed and replaced while the file body, shebang and
+    encoding declaration are preserved. Returns a (possibly empty) warning string.
+    """
     project_name = config.name.strip()
     license_str = config.license
     url = getattr(config, 'url', None)
-    copyright_statement = getattr(
-        config,
-        'copyright_statement',
-        'The copyright lies with the authors of this file (see below).',
-    )
+    copyright_statement = getattr(config, 'copyright_statement', _DEFAULT_COPYRIGHT)
     max_width = getattr(config, 'max_width', 78)
     prefix = getattr(config, 'prefix', '#')
     lead_out = getattr(config, 'lead_out', None)
@@ -277,9 +331,10 @@ def process_file(filename, config, root):
     source.append(None)
     source_iter = iter(source)
 
-    print('*' * 88)
-    print(license_str)
-    print('*' * 88)
+    if verbose:
+        print('*' * 88)
+        print(license_str)
+        print('*' * 88)
     header, warning, last_header_line = read_current_header(
         source_iter,
         prefix,
@@ -318,9 +373,11 @@ def process_file(filename, config, root):
     return warning
 
 
-def main():
+def main() -> None:
+    """CLI entry point: load the config module and process the requested path."""
     args = docopt(__doc__)
     cfg = args['--cfg']
+    verbose = bool(args['--verbose'])
 
     spec = importlib.util.spec_from_file_location('config', cfg)
     if spec is None or spec.loader is None:
@@ -333,7 +390,7 @@ def main():
         display_name = filename[len(dirname) :] if dirname and filename.startswith(dirname) else filename
         print(f'{display_name}: ', end='')
         try:
-            result = process_file(filename, config, dirname if dirname else '.')
+            result = process_file(filename, config, dirname if dirname else '.', verbose=verbose)
             print(result if result else 'success')
         except GitError as error:
             print(error)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,1 +1,78 @@
-"""Add fixtures here if needed"""
+"""Shared pytest fixtures for the pylicense3 test-suite."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def make_config():
+    """Return a factory building a minimal config object understood by the CLI.
+
+    ``cli.process_file`` reads ``config.name`` / ``config.license`` directly and
+    looks the rest up via ``getattr``; a ``SimpleNamespace`` mirrors that contract
+    without needing an importable module on disk.
+    """
+
+    def _make(**overrides: object) -> SimpleNamespace:
+        attributes: dict[str, object] = {'name': 'Example Project', 'license': 'BSD-2-Clause'}
+        attributes.update(overrides)
+        return SimpleNamespace(**attributes)
+
+    return _make
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path):
+    """Create an isolated throwaway git repository under ``tmp_path``.
+
+    Returns a namespace exposing the repo ``path`` and a ``commit`` helper that
+    records a file with a specific author and calendar year, so author/year
+    extraction can be exercised deterministically.
+    """
+    if shutil.which('git') is None:
+        pytest.skip('git is not available')
+
+    repo = tmp_path / 'repo'
+    repo.mkdir()
+
+    # Pin config to the repo so the host machine's global identity cannot interfere.
+    base_env = {**os.environ, 'GIT_CONFIG_GLOBAL': os.devnull, 'GIT_CONFIG_SYSTEM': os.devnull}
+
+    def run(*args: str, env_extra: dict[str, str] | None = None) -> None:
+        env = dict(base_env)
+        if env_extra:
+            env.update(env_extra)
+        subprocess.run(['git', *args], cwd=repo, check=True, capture_output=True, text=True, env=env)
+
+    run('init')
+    run('config', 'user.name', 'Default User')
+    run('config', 'user.email', 'default@example.com')
+
+    def commit(path: str, content: str, author_name: str, author_email: str, year: int) -> None:
+        file_path = repo / path
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text(content)
+        run('add', path)
+        date = f'{year}-01-01T00:00:00'
+        run(
+            'commit',
+            '-m',
+            f'update {path}',
+            env_extra={
+                'GIT_AUTHOR_NAME': author_name,
+                'GIT_AUTHOR_EMAIL': author_email,
+                'GIT_AUTHOR_DATE': date,
+                'GIT_COMMITTER_NAME': author_name,
+                'GIT_COMMITTER_EMAIL': author_email,
+                'GIT_COMMITTER_DATE': date,
+            },
+        )
+
+    return SimpleNamespace(path=repo, run=run, commit=commit)

--- a/tests/test_pylicense3.py
+++ b/tests/test_pylicense3.py
@@ -2,6 +2,19 @@
 
 """Tests for `pylicense3` package."""
 
+from io import StringIO
+from pathlib import Path
+
+from pylicense3.cli import (
+    _compile_patterns,
+    _format_year_range,
+    get_git_authors,
+    process_dir,
+    process_file,
+    read_current_header,
+    write_header,
+)
+
 
 def test_version():
     import pylicense3
@@ -13,3 +26,151 @@ def test_import():
     import pylicense3
 
     assert pylicense3 is not None
+
+
+def test_compile_patterns_defaults_to_match_all():
+    pattern = _compile_patterns([])
+    assert pattern.match('anything/at/all.py')
+
+
+def test_compile_patterns_matches_globs():
+    pattern = _compile_patterns(['*.py'])
+    assert pattern.match('module.py')
+    assert not pattern.match('module.txt')
+
+
+def test_format_year_range_single_year():
+    assert _format_year_range(2020) == '2020'
+
+
+def test_format_year_range_span():
+    assert _format_year_range((2020, 2023)) == '2020 - 2023'
+
+
+def test_get_git_authors_collapses_consecutive_years(git_repo):
+    git_repo.commit('file.py', 'v1\n', 'Alice', 'alice@example.com', 2020)
+    git_repo.commit('file.py', 'v2\n', 'Alice', 'alice@example.com', 2021)
+    git_repo.commit('file.py', 'v3\n', 'Bob', 'bob@example.com', 2022)
+    git_repo.commit('file.py', 'v4\n', 'Alice', 'alice@example.com', 2024)
+
+    authors = get_git_authors(str(git_repo.path / 'file.py'), str(git_repo.path))
+
+    assert authors['Alice'] == '2020 - 2021, 2024'
+    assert authors['Bob'] == '2022'
+
+
+def test_read_current_header_parses_and_discards_boilerplate():
+    source = [
+        '#!/usr/bin/env python\n',
+        '# -*- coding: utf-8 -*-\n',
+        '# Example Project (https://example.org).\n',
+        '# The copyright lies with the authors of this file (see below).\n',
+        '# License: BSD-2-Clause\n',
+        '# Authors:\n',
+        '#   Alice (2020)\n',
+        '# keep this comment\n',
+        '\n',
+        None,
+    ]
+    header, warning, last_line = read_current_header(
+        iter(source),
+        prefix='#',
+        project_name='Example Project',
+        copyright_statement='The copyright lies with the authors of this file (see below).',
+        license_str='BSD-2-Clause',
+        url='https://example.org',
+        lead_in=None,
+        lead_out=None,
+    )
+
+    assert header['shebang'] == '#!/usr/bin/env python'
+    assert 'coding' in (header['encoding'] or '')
+    assert any('keep this comment' in comment for comment in header['comments'])
+    # Regenerated boilerplate must not survive into the preserved comments.
+    assert not any('Example Project' in comment for comment in header['comments'])
+    assert not any('Authors' in comment for comment in header['comments'])
+    assert warning == ''
+    assert last_line == '\n'
+
+
+def test_read_current_header_warns_about_stray_url():
+    source = ['# https://stray.example/link\n', '\n', None]
+    _header, warning, _last_line = read_current_header(
+        iter(source),
+        prefix='#',
+        project_name='Example Project',
+        copyright_statement='Copyright statement here',
+        license_str='BSD-2-Clause',
+        url=None,
+        lead_in=None,
+        lead_out=None,
+    )
+
+    assert 'stray.example' in warning
+
+
+def test_write_header_renders_full_block():
+    header = {'shebang': '#!/usr/bin/env python', 'encoding': None, 'comments': ['# keep me\n']}
+    target = StringIO()
+
+    write_header(
+        target,
+        header,
+        {'Alice': '2020'},
+        license_str='BSD-2-Clause',
+        prefix='#',
+        project_name='Example Project',
+        url='https://example.org',
+        max_width=78,
+        copyright_statement='Copyright statement here',
+        lead_in=None,
+        lead_out=None,
+    )
+
+    text = target.getvalue()
+    assert '#!/usr/bin/env python' in text
+    assert '# Example Project (https://example.org).' in text
+    assert '# Copyright statement here' in text
+    assert '# License: BSD-2-Clause' in text
+    assert '# Authors:' in text
+    assert 'Alice (2020)' in text
+    assert '# keep me' in text
+
+
+def test_process_file_rewrites_header_and_preserves_body(git_repo, make_config):
+    # Ensure HEAD exists so the eager git-author lookup returns cleanly.
+    git_repo.commit('seed.txt', 'seed\n', 'Seed', 'seed@example.com', 2019)
+    source = git_repo.path / 'mod.py'
+    source.write_text('print("hello")\n')
+    config = make_config(url='https://example.org', contributors_team='Alice (2020)')
+
+    warning = process_file(str(source), config, str(git_repo.path))
+
+    result = source.read_text()
+    assert '# Example Project (https://example.org).' in result
+    assert '# Alice (2020)' in result
+    assert 'print("hello")' in result
+    assert warning == ''
+
+
+def test_process_dir_applies_include_and_exclude(tmp_path, make_config):
+    (tmp_path / 'a.py').write_text('x\n')
+    (tmp_path / 'b.txt').write_text('x\n')
+    sub = tmp_path / 'sub'
+    sub.mkdir()
+    (sub / 'c.py').write_text('x\n')
+
+    config = make_config(include_patterns=['*.py'], exclude_patterns=['sub/*'])
+    results = list(process_dir(str(tmp_path), config))
+
+    names = sorted(Path(filename).name for filename, _root in results)
+    assert names == ['a.py']
+
+
+def test_process_dir_yields_single_file(tmp_path, make_config):
+    single = tmp_path / 'only.py'
+    single.write_text('x\n')
+
+    results = list(process_dir(str(single), make_config()))
+
+    assert results == [(str(single), '')]


### PR DESCRIPTION
## Context

The project's infrastructure is already modern and healthy (Python 3.10+, `uv`, `hatchling` + `hatch-vcs`, `ruff`, pre-commit, multi-OS CI on 3.10/3.14), so this is **not** a packaging change. The real gaps were inside `pylicense3/cli.py` — incomplete typing, an unused CLI flag, noisy default output, a few dated idioms — and the **near-empty test suite** (only `test_version` / `test_import` covered the 344-line module).

This PR makes safe, behavior-preserving cleanups, fixes the one clear flag/output bug, and gives the core logic real coverage. Two behavior-*ambiguous* smells were deliberately left for a separate decision and filed as issues instead.

## Changes

### Code-quality cleanups (`pylicense3/cli.py`, behavior-preserving)
- Complete type hints + docstrings on the previously untyped functions (`process_dir`, `get_git_authors`, `read_current_header`, `write_header`, `process_file`, `main`); added a `TypedDict` (`FileHeader`) for the parsed header dict.
- Simplified the BOM-stripping loop (nested loop → single `str.lstrip` over the BOM bytes).
- Replaced `line[len(prefix):]` slicing with `str.removeprefix(prefix)` (line already guarantees the prefix is present).
- Hoisted magic literals (BOM bytes, discard prefixes, URL schemes, default copyright statement) to module-level constants.

### Wire up `--verbose`
The `-v`/`--verbose` flag was declared and parsed but never read, while the per-file `*** / license / ***` banner printed for **every** file. It is now gated behind `-v`; normal `name: success` output is unchanged. Verified manually with and without `-v`.

### Test suite
Expanded from 2 smoke tests to cover `_compile_patterns`, `_format_year_range`, `get_git_authors` (via a throwaway git repo fixture), `read_current_header`, `write_header`, `process_file` (round-trip) and `process_dir` filtering. Shared fixtures live in `tests/fixtures.py` (already registered via `conftest.py`). `cli.py` coverage rises from ~0% to ~82%.

## Verification
- `ruff check .` and `ruff format --check .` — clean.
- `pytest` — 13 passed, coverage reported.
- Manual smoke test of `--verbose` on a sample repo (banner only with `-v`, header written correctly either way).

## Deferred (filed as issues, not changed here)
- #104 — URL-indent branch in `write_header` whose condition is effectively always true.
- #105 — `process_file` return value overloading "warning" and "success".

These touch ambiguous behavior, so they await a design decision before being changed.

https://claude.ai/code/session_014mZ7q1PFZJoHkPw5uHynpX